### PR TITLE
Fix installing pc1 repos on ubuntu

### DIFF
--- a/data/puppet_debugging_kit/files/bootstrap-pc1.sh
+++ b/data/puppet_debugging_kit/files/bootstrap-pc1.sh
@@ -42,7 +42,7 @@ case $PKG_SYS in
       apt-get install -y curl
       curl -O "http://apt.puppetlabs.com/puppetlabs-release-pc1-$DEB_RELEASE.deb"
       dpkg -i "puppetlabs-release-pc1-$DEB_RELEASE.deb"
-      apt-get -y -f -m update
+      apt-get -y -m update
     fi
     ;;
 esac


### PR DESCRIPTION
This commit resolves https://github.com/Sharpie/puppet-debugging-kit/issues/10
by removing the `-f` flag from agt-get update