### PR TITLE
Update memory tuning roles to reduce orch services heap

### DIFF
--- a/data/puppet_debugging_kit/files/pe-memory-tuning.yaml
+++ b/data/puppet_debugging_kit/files/pe-memory-tuning.yaml
@@ -13,16 +13,24 @@ puppet_enterprise::profile::master::java_args:
   Xms: '128m'
   'XX:MaxPermSize': '=96m'
   'XX:PermSize': '=64m'
+  'XX:+UseG1GC': ''
 puppet_enterprise::profile::puppetdb::java_args:
   Xmx: '128m'
   Xms: '64m'
   'XX:MaxPermSize': '=96m'
   'XX:PermSize': '=64m'
+  'XX:+UseG1GC': ''
 puppet_enterprise::profile::console::java_args:
   Xmx: '64m'
   Xms: '64m'
   'XX:MaxPermSize': '=96m'
   'XX:PermSize': '=64m'
+  'XX:+UseG1GC': ''
 puppet_enterprise::profile::console::delayed_job_workers: 1
 #shared_buffers takes affect during install but is not managed after
 puppet_enterprise::profile::database::shared_buffers: '4MB'
+#2015.3.2 and above
+puppet_enterprise::profile::orchestrator::java_args:
+  Xmx: '64m'
+  Xms: '64m'
+  'XX:+UseG1GC': ''


### PR DESCRIPTION
Prior to this commit, orchestration services was not tuned
and defaulted to 192MB of RAM at install.

After this commit, orchestration services is tuned to 64MB of heap
and all services now use GC1 for garbage collection