### PR TITLE
Use sizes instead of GB of RAM roles

### DIFF
--- a/config/vms.yaml.example
+++ b/config/vms.yaml.example
@@ -15,7 +15,7 @@ vms:
       - pe-memory-tuning2
       - el-stop-firewall
       - el-fix-path
-      - 4gb-memory
+      - medium-size
       - base
 
   - name: pe-201711-agent
@@ -35,7 +35,7 @@ vms:
       - pe-memory-tuning2
       - el-stop-firewall
       - el-fix-path
-      - 2gb-memory
+      - medium-size
       - base
 
   - name: pe-201643-agent
@@ -55,7 +55,7 @@ vms:
       - pe-memory-tuning
       - el-stop-firewall
       - el-fix-path
-      - 2gb-memory
+      - medium-size
       - base
 
   - name: pe-387-agent


### PR DESCRIPTION
Size roles were added in https://github.com/Sharpie/puppet-debugging-kit/pull/12

Memory consumption was lowered in https://github.com/Sharpie/puppet-debugging-kit/pull/13

