### PR TITLE
Update orchestrator heap size

### DIFF
--- a/data/puppet_debugging_kit/files/pe-memory-tuning.yaml
+++ b/data/puppet_debugging_kit/files/pe-memory-tuning.yaml
@@ -40,6 +40,6 @@ puppet_enterprise::profile::console::delayed_job_workers: 1
 puppet_enterprise::profile::database::shared_buffers: '4MB'
 #2015.3.2 and above
 puppet_enterprise::profile::orchestrator::java_args:
-  Xmx: '64m'
-  Xms: '64m'
+  Xmx: '128m'
+  Xms: '128m'
   'XX:+UseG1GC': ''


### PR DESCRIPTION
Orchestrator heap has a new minimum in 2019.2.  Without exhaustive testing I just doubled the existing heap size.