### PR TITLE
Ignore the .env file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ src/puppetlabs
 .bolt
 modules
 Puppetfile
+.env

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,6 @@ Gemfile.lock
 bin
 config/*.yaml
 src/puppetlabs
+.bolt
+modules
+Puppetfile

--- a/Gemfile
+++ b/Gemfile
@@ -5,11 +5,11 @@ source 'https://rubygems.org'
 eval(File.read("#{__FILE__}.local"), binding) if File.exists? "#{__FILE__}.local"
 
 gem 'vagrant', :git => 'https://github.com/hashicorp/vagrant.git',
-  :tag => 'v2.1.2'
+  :tag => 'v2.2.4'
 
 # Gems listed in this group are automatically loaded by the Vagrantfile which
 # simulates the action of `vagrant plugin`, which is inactive when running
 # under Bundler.
 group :plugins do
-  gem 'oscar', '>= 0.5.4'
+  gem 'oscar', '>= 0.5.6'
 end

--- a/Gemfile
+++ b/Gemfile
@@ -5,7 +5,7 @@ source 'https://rubygems.org'
 eval(File.read("#{__FILE__}.local"), binding) if File.exists? "#{__FILE__}.local"
 
 gem 'vagrant', :git => 'https://github.com/hashicorp/vagrant.git',
-  :tag => 'v2.2.4'
+  :tag => 'v2.2.5'
 
 # Gems listed in this group are automatically loaded by the Vagrantfile which
 # simulates the action of `vagrant plugin`, which is inactive when running

--- a/Gemfile
+++ b/Gemfile
@@ -11,5 +11,5 @@ gem 'vagrant', :git => 'https://github.com/hashicorp/vagrant.git',
 # simulates the action of `vagrant plugin`, which is inactive when running
 # under Bundler.
 group :plugins do
-  gem 'oscar', '>= 0.5.6'
+  gem 'oscar', '>= 0.6.0'
 end

--- a/Puppetfile.example
+++ b/Puppetfile.example
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+forge "http://forge.puppetlabs.com"
+
+moduledir File.join(File.dirname(__FILE__), 'modules')
+
+mod 'local', local: true
+
+mod 'deploy_pe',
+  :git => 'https://github.com/jarretlavallee/puppet-deploy_pe.git'
+
+mod 'puppetlabs-ruby_task_helper', '0.3.0'
+mod 'puppetlabs-apt', '7.1.0'
+mod 'puppetlabs-stdlib'
+mod 'puppetlabs-bootstrap', '1.0.0'
+mod 'puppetlabs-puppet_conf', '0.3.1'
+mod 'nate-purge_node', '1.3.1'
+mod 'sign_cert',
+  :git => 'https://github.com/m0dular/sign_cert.git'

--- a/Puppetfile.example
+++ b/Puppetfile.example
@@ -6,14 +6,12 @@ moduledir File.join(File.dirname(__FILE__), 'modules')
 
 mod 'local', local: true
 
-mod 'deploy_pe',
-  :git => 'https://github.com/jarretlavallee/puppet-deploy_pe.git'
-
 mod 'puppetlabs-ruby_task_helper', '0.3.0'
 mod 'puppetlabs-apt', '7.1.0'
 mod 'puppetlabs-stdlib'
 mod 'puppetlabs-bootstrap', '1.0.0'
 mod 'puppetlabs-puppet_conf', '0.3.1'
 mod 'nate-purge_node', '1.3.1'
-mod 'sign_cert',
-  :git => 'https://github.com/m0dular/sign_cert.git'
+mod 'm0dular-sign_cert', '0.1.1'
+mod 'm0dular-run_agent', '0.1.1'
+mod 'jarretlavallee-deploy_pe', '0.1.0'

--- a/README.md
+++ b/README.md
@@ -16,9 +16,7 @@ This project provides a batteries-included Vagrant environment for debugging Pup
     * [General-Purpose Roles](#general-purpose-roles)
     * [PE-Specific Roles](#pe-specific-roles)
     * [POSS-Specific Roles](#poss-specific-roles)
-  * [Running on Platform9](#running-on-platform9)
-    * [Troubleshooting the openstack provider](#troubleshooting-the-openstack-provider)
-    * [Password troubleshooting](#password-troubleshooting)
+  * [Bolt Based Provisioning](#bolt-based-provisioning)
 * [Extending and Contributing](#extending-and-contributing)
 
 <!-- vim-markdown-toc -->
@@ -34,11 +32,14 @@ Getting the debugging kit ready for use consists of three steps:
   3. [Clone Puppet Open Source projects](#clone-puppet-open-source-projects) to
      `src/puppetlabs` _(optional)_.
 
+  4. [Install Bolt](https://puppet.com/docs/bolt/latest/bolt_installing.html) to
+      enable bolt provisioning _(optional)_.
+
 Rake tasks and templates are provided to help with all three steps.
 
 ### Install Vagrant Plugins
 
-Two methods are avaible depending on whether a global Vagrant installation,
+Two methods are available depending on whether a global Vagrant installation,
 such as provided by the official packages from
 [vagrantup.com](http://vagrantup.com), is in use:
 
@@ -89,6 +90,11 @@ Use of the debugging kit consists of:
     - The default roles can be found in
       [`data/puppet_debugging_kit/roles.yaml`][roles_yaml], and are explained
       in more detail below.
+  - Optionally using ["bolt based provisioning"](#bolt-based-provisioning)
+    - Building roles to call Bolt modules.
+    - Roles can contain triggers or provisioners to initiate plans, tasks, or commands.
+    - An example set are found in `config/bolt_vms.yaml.example`.
+    - An example Puppetfile is found in `Puppetfile.example`.
 
 
 ### Roles
@@ -178,10 +184,32 @@ There are also roles for legacy POSS software:
   - <a id="el-6-ruby200" /> **`el-6-ruby200`**: Provides Ruby 2.0.0 on EL6
     (requires the role [`el-6-epel`](#el-6-epel))
 
+### Bolt Based Provisioning
+
+Bolt modules can now be used to do the provisoning and configuration of the machines. An example set of plans have been provided in the `Puppetfile.example` which will enable provisioning a PE infrastructure. To use the bolt plans from the `Puppetfile` the following steps can be followed.
+
+  1. [Install Bolt](https://puppet.com/docs/bolt/latest/bolt_installing.html) as needed.
+  2. Copy the `Puppetfile.example` to `Puppetfile` and add any additional modules.
+  3. Install the modules with `vagrant bolt puppetfile install`.
+  4. Copy the `config/bolt_vms.yaml.example` to `config/bolt_vms.yaml`.
+  5. Update any parameters in the `roles` of the `config/bolt_vms.yaml` to specify PE versions or download locations.
+
+The example VMs in the `config/bolt_vms.yaml` use custom roles at the bottom of the file. There are roles to deploy a PE master, agent, and compiler. See the [`deploy_pe`](https://forge.puppet.com/jarretlavallee/deploy_pe) module for more parameter information.
+
+  - **pe_master**
+    Installs the PE master on the VM using the specified parameters.
+  - **pe_compiler**
+    Installs a PE compiler from the PE master.
+  - **pe_agent**
+    Installs a PE agent from the PE master.
+
+The roles define provisioners and triggers. More information on how to use the bolt triggers and provisioners can be found in the [`vagrant-bolt` documentation](https://github.com/oscar-stack/vagrant-bolt#config-builder).
+
+This is currently only for *nix vagrant hosts. Windows vagrant host compatibility is in progress in the example plans.
 
 ## Extending and Contributing
 
-The debugging kit can be thought of as a library of configuration and data for [Oscar](https://github.com/adrienthebo/oscar).
+The debugging kit can be thought of as a library of configuration and data for [Oscar](https://github.com/oscar-stack/oscar).
 Data is loaded from two sets of YAML files:
 
 ```

--- a/config/bolt_vms.yaml.example
+++ b/config/bolt_vms.yaml.example
@@ -1,0 +1,81 @@
+---
+# This example set uses Bolt tasks and plans to deploy the PE nodes
+# Please ensure to have bolt installed on the machine
+# Please also ensure to copy the `Puppetfile.example` to `Puppetfile` 
+# and run `vagrant bolt puppetfile install` in the root of this directory
+#
+# The PE version and parameters can be changed in the roles at the bottom
+# of this file.
+
+vm_defaults:
+  bolt:
+    run_as: root
+  box: bento/centos-7
+
+vms:
+  - name: master
+    hostname: master.puppetdebug.vlan
+    roles:
+      - pe_master
+      - medium-size
+      - base
+
+  - name: compiler
+    hostname: compiler.puppetdebug.vlan
+    roles:
+      - pe_compiler
+      - medium-size
+      - base
+
+  - name: agent
+    roles:
+      - pe_agent
+      - small-size
+      - base
+
+roles:
+  pe_agent:
+    bolt_triggers:
+      - trigger_type: :after
+        trigger_commands:
+          - :up
+          - :provision
+        command: plan
+        name: deploy_pe::provision_agent
+        params:
+          master: master
+      - trigger_type: :before
+        trigger_commands:
+          - :destroy
+        command: plan
+        name: deploy_pe::decom_agent
+        params:
+          master: master
+
+
+  pe_master:
+    provisioners:
+      - type: bolt
+        command: plan
+        name: deploy_pe::provision_master
+        params:
+          # installer_tarball: /vagrant/puppet-enterprise-2019.1.0-el-7-x86_64.tar.gz
+          version: 2019.1.1
+          pe_settings:
+            password: puppetlabs
+
+  pe_compiler:
+    provisioners:
+      - type: bolt
+        command: plan
+        name: deploy_pe::provision_compiler
+        params:
+          master: master
+    bolt_triggers:
+      - trigger_type: :before
+        trigger_commands:
+          - :destroy
+        command: plan
+        name: deploy_pe::decom_agent
+        params:
+          master: master

--- a/config/bolt_vms.yaml.example
+++ b/config/bolt_vms.yaml.example
@@ -33,6 +33,9 @@ vms:
       - small-size
       - base
 
+# Roles to be used with the VMs
+# Bolt Provisioner and Trigger settings deploy and install PE using plans
+# More information on the syntax and usage of bolt in this file can be found in https://github.com/oscar-stack/vagrant-bolt#config-builder
 roles:
   pe_agent:
     bolt_triggers:
@@ -58,9 +61,10 @@ roles:
       - type: bolt
         command: plan
         name: deploy_pe::provision_master
-        params:
-          # installer_tarball: /vagrant/puppet-enterprise-2019.1.0-el-7-x86_64.tar.gz
-          version: 2019.1.1
+        params: # More parameters are avilable see https://forge.puppet.com/jarretlavallee/deploy_pe/reference
+          # installer_tarball: /vagrant/puppet-enterprise-2019.1.1-el-7-x86_64.tar.gz # Local tarball in the vagrant directory
+          # download_url: http://example.com/pe/puppet-enterprise-2019.1.1-el-7-x86_64.tar.gz # Download the tarball from the specified URL
+          version: 2019.1.1 # Download the PE tarball from puppet.com
           pe_settings:
             password: puppetlabs
 

--- a/rsync_ignore
+++ b/rsync_ignore
@@ -3,3 +3,4 @@
 .git
 .pe_build
 .bolt
+.env

--- a/rsync_ignore
+++ b/rsync_ignore
@@ -2,3 +2,4 @@
 .bundle
 .git
 .pe_build
+.bolt


### PR DESCRIPTION
This PR is rebased onto #21, so it will need to be merged first. This PR ignores the `.env` file in the debugging kit's gitignore and the `rsync_ignore`. This enables the use of `.env` files within the directory.

More information on dotenv will depend on the user's shell. One can set the `VAGRANT_DEFAULT_PROVIDER` and other non-sensitive provider environment variables in this file.